### PR TITLE
Update module to be py3 compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+.python-version

--- a/README.rst
+++ b/README.rst
@@ -18,8 +18,8 @@ before installing this package.
 
 Support for OSX is not quite there yet, mainly because OpenMP isn't supported
 on clang. Homebrew is still on 1.1.0, so you'll need to compile and install
-clustalo 1.2.0 yourself (`--without-openmp`). You'll also need to modify the
-setup.py file to leave out `gomp` and `-fopenmp` when installing.
+clustalo 1.2.0 yourself (`--without-openmp`). You'll also need to set
+`OPENMP_DISABLED=true` in env vars before running build/install.
 
 Usage
 -----


### PR DESCRIPTION
## Description

Updates module initialization macros as well as string handling of
sequence names and bases. This porting is heavily based off
http://python3porting.com/cextensions.html

Also makes minor fixes to README and .gitgnore.

## Test Plan

Test on python3:

```
$ python --version
Python 3.7.6
$ OPENMP_DISABLED=1 python setup.py install
$ python
# expects py3 string values
from clustalo import clustalo
clustalo({"x": "AAAA", "\u2014": "TTTT"})
# note that bytes crash it
clustalo({b"\u2014": "AAAA", "T": "TTTT"})
[1]    52942 segmentation fault  python
```

Test on python2:

```
$ python --version
Python 2.7.17
$ OPENMP_DISABLED=1 python setup.py install
$ python
from clustalo import clustalo
# works with str and ascii unicode
>>> clustalo({"x": "AAAA", u"y": "TTTT"})
{'y': 'TTTT', 'x': 'AAAA'}
# note that non-ascii unicode crashes it
clustalo({"x": "AAAA", u"\u2014": "TTTT"})
[1]    62061 segmentation fault  python
```