### PR TITLE
Add output_order keyword for returning the dictionary with the alignment order (rather than input order)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 *.py[cod]
 
 # C extensions

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+venv
 .idea
 *.py[cod]
 

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,7 @@
+### Beowulfey's notes:
+
+I've forked this repository in order to add the ability to return the sequences of the alignment in the aligned tree order. Although there isn't an option in the clustalo API I figured out how it knows whether to do so (it's dependendent on whether memory is allocated for the tree order, I guess). Thanks to ordered dictionaries in Python 3 this actually works, too! 
+
 clustalo-python
 ===============
 

--- a/clustalo.c
+++ b/clustalo.c
@@ -74,6 +74,11 @@ clustalo_clustalo(PyObject *self, PyObject *args, PyObject *keywds)
     rAlnOpts.iNumIterations = numCombinedIterations;
     rAlnOpts.iMaxGuidetreeIterations = maxGuidetreeIterations;
     rAlnOpts.iMaxHMMIterations = maxHMMIterations;
+
+    // allocating the tree_order of prMSeq is enough to capture the tree_order information
+    if (outOrder == 1) {
+        prMSeq->tree_order = (int *)CKMALLOC(prMSeq->nseqs * sizeof(int));
+    }
     rAlnOpts.iOutputOrder = outOrder;
 
     // Read in sequences from input.
@@ -128,22 +133,17 @@ clustalo_clustalo(PyObject *self, PyObject *args, PyObject *keywds)
         for (idx = 0; idx < prMSeq->nseqs; idx++) {
             //printf("NAME OF SEQUENCE: %s, %i \n", prMSeq->sqinfo[prMSeq->tree_order[idx]].name, prMSeq->tree_order[idx]);
             const char *key = prMSeq->sqinfo[prMSeq->tree_order[idx]].name;
-
 #if PY_MAJOR_VERSION >= 3
             PyObject *value = PyUnicode_FromString(prMSeq->seq[prMSeq->tree_order[idx]]);
 #else
             PyObject *value = PyString_FromString(prMSeq->seq[prMSeq->tree_order[idx]]);
-
 #endif
             PyDict_SetItemString(returnDict, key, value);
         }
-
-
     }
     else {
         for (idx = 0; idx < prMSeq->nseqs; idx++) {
             const char *key = prMSeq->sqinfo[idx].name;
-
 #if PY_MAJOR_VERSION >= 3
             PyObject *value = PyUnicode_FromString(prMSeq->seq[idx]);
 #else
@@ -154,7 +154,6 @@ clustalo_clustalo(PyObject *self, PyObject *args, PyObject *keywds)
     }
     return returnDict;
 }
-
 #if PY_MAJOR_VERSION >= 3
   #define MOD_ERROR_VAL NULL
   #define MOD_SUCCESS_VAL(val) val
@@ -174,21 +173,22 @@ clustalo_clustalo(PyObject *self, PyObject *args, PyObject *keywds)
 
 static PyMethodDef ClustaloMethods[] = {
     {"clustalo",  (PyCFunction)clustalo_clustalo, METH_VARARGS | METH_KEYWORDS,
-     "Runs clustal omega."
-     ""
-     "Args:"
-     "  data (dict): dictionary of sequence_name => bases"
-     ""
-     "Kwargs:"
-     "  seqtype (int): should be one of clustalo.DNA, clustalo.RNA, or clustalo.PROTEIN"
-     "  mbed_guide_tree (bool): whether mBed-like clustering guide tree should be used"
-     "  mbed_iteration (bool): whether mBed-like clustering iteration should be used"
-     "  num_combined_iterations (int): number of (combined guide-tree/HMM) iterations"
-     "  max_guidetree_iterations (int): max guide tree iterations within combined iterations"
-     "  max_hmm_iterations (int): max HMM iterations within combined iterations"
-     "  num_threads (int): number of threads to use (requires libclustalo compiled with OpenMP)"
-     ""
-     "Returns dict of sequence_named => aligned_bases ('_' for gaps)"},
+     "Runs clustal omega.\n"
+     "\n"
+     "Args:\n"
+     "  data (dict): dictionary of sequence_name => bases\n"
+     "\n"
+     "Kwargs:\n"
+     "  seqtype (int): should be one of clustalo.DNA, clustalo.RNA, or clustalo.PROTEIN\n"
+     "  mbed_guide_tree (bool): whether mBed-like clustering guide tree should be used\n"
+     "  mbed_iteration (bool): whether mBed-like clustering iteration should be used\n"
+     "  num_combined_iterations (int): number of (combined guide-tree/HMM) iterations\n"
+     "  max_guidetree_iterations (int): max guide tree iterations within combined iterations\n"
+     "  max_hmm_iterations (int): max HMM iterations within combined iterations\n"
+     "  num_threads (int): number of threads to use (requires libclustalo compiled with OpenMP)\n"
+     "  output_order (int): return the alignment with either the input order (0) or alignment tree order (1)\n"
+     "\n"
+     "Returns dict of sequence_names:aligned_bases ('-' for gaps)\n"},
     {NULL, NULL, 0, NULL}
 };
 

--- a/clustalo.c
+++ b/clustalo.c
@@ -110,6 +110,7 @@ clustalo_clustalo(PyObject *self, PyObject *args, PyObject *keywds)
     }
 
     // allocating the tree_order of prMSeq is enough to capture the tree_order information
+    // Segfaults if only 2 sequences though (the program refuses to calculate a tree)
     if (prMSeq->nseqs > 2 && outOrder == 1) {
         prMSeq->tree_order = (int *) CKMALLOC(prMSeq->nseqs * sizeof(int));
     }

--- a/clustalo.c
+++ b/clustalo.c
@@ -188,7 +188,7 @@ static PyMethodDef ClustaloMethods[] = {
      "  max_guidetree_iterations (int): max guide tree iterations within combined iterations\n"
      "  max_hmm_iterations (int): max HMM iterations within combined iterations\n"
      "  num_threads (int): number of threads to use (requires libclustalo compiled with OpenMP)\n"
-     "  output_order (int): return the alignment with either the input order (0) or alignment tree order (1)\n"
+     "  output_order (int): return the alignment with either the input order (0) or alignment tree order (1). Only works on >Python 3.6, where dictionaries are ordered.\n"
      "\n"
      "Returns dict of sequence_names:aligned_bases ('-' for gaps)\n"},
     {NULL, NULL, 0, NULL}

--- a/clustalo.c
+++ b/clustalo.c
@@ -75,12 +75,6 @@ clustalo_clustalo(PyObject *self, PyObject *args, PyObject *keywds)
     rAlnOpts.iMaxGuidetreeIterations = maxGuidetreeIterations;
     rAlnOpts.iMaxHMMIterations = maxHMMIterations;
 
-    // allocating the tree_order of prMSeq is enough to capture the tree_order information
-    if (outOrder == 1) {
-        prMSeq->tree_order = (int *)CKMALLOC(prMSeq->nseqs * sizeof(int));
-    }
-    rAlnOpts.iOutputOrder = outOrder;
-
     // Read in sequences from input.
     PyObject *key, *value;
     Py_ssize_t pos = 0;
@@ -115,6 +109,14 @@ clustalo_clustalo(PyObject *self, PyObject *args, PyObject *keywds)
         return PyDict_Copy(inputDict);
     }
 
+    // allocating the tree_order of prMSeq is enough to capture the tree_order information
+    if (prMSeq->nseqs > 2 && outOrder == 1) {
+        prMSeq->tree_order = (int *) CKMALLOC(prMSeq->nseqs * sizeof(int));
+    }
+    else {
+        outOrder = 0;
+    }
+
     // Perform the alignment.
     int rv;
     Py_BEGIN_ALLOW_THREADS
@@ -131,7 +133,6 @@ clustalo_clustalo(PyObject *self, PyObject *args, PyObject *keywds)
     int idx;
     if (outOrder == 1){
         for (idx = 0; idx < prMSeq->nseqs; idx++) {
-            //printf("NAME OF SEQUENCE: %s, %i \n", prMSeq->sqinfo[prMSeq->tree_order[idx]].name, prMSeq->tree_order[idx]);
             const char *key = prMSeq->sqinfo[prMSeq->tree_order[idx]].name;
 #if PY_MAJOR_VERSION >= 3
             PyObject *value = PyUnicode_FromString(prMSeq->seq[prMSeq->tree_order[idx]]);

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ if not OPENMP_DISABLED:
 
 module = Extension('clustalo',
                    sources = ['clustalo.c'],
-                   include_dirs=['/usr/local/sci/clustalo/current/include/clustalo'],
-                   library_dirs=['/usr/local/sci/clustalo/current/lib'],
+                   include_dirs=['/usr/local/sci/clustalo/v1.2.4/include/clustalo'],
+                   library_dirs=['/usr/local/sci/clustalo/v1.2.4/lib'],
                    libraries=libraries,
                    extra_compile_args=extra_compile_args)
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ if not OPENMP_DISABLED:
 
 module = Extension('clustalo',
                    sources = ['clustalo.c'],
-                   include_dirs=['/usr/include/clustalo', '/usr/local/include/clustalo'],
+                   include_dirs=['/usr/local/sci/clustalo/current/include/clustalo'],
+                   library_dirs=['/usr/local/sci/clustalo/current/lib'],
                    libraries=libraries,
                    extra_compile_args=extra_compile_args)
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ module = Extension('clustalo',
                    extra_compile_args=extra_compile_args)
 
 setup(name='clustalo',
-      version='0.1.2',
+      version='0.1.3',
       description='Python wrapper around libclustalo',
       author='Benchling Engineering',
       author_email='eng@benchling.com',

--- a/venv/pyvenv.cfg
+++ b/venv/pyvenv.cfg
@@ -1,0 +1,8 @@
+home = /usr
+implementation = CPython
+version_info = 3.8.2.final.0
+virtualenv = 20.0.20
+include-system-site-packages = false
+base-prefix = /usr
+base-exec-prefix = /usr
+base-executable = /usr/bin/python3

--- a/venv/pyvenv.cfg
+++ b/venv/pyvenv.cfg
@@ -1,8 +1,0 @@
-home = /usr
-implementation = CPython
-version_info = 3.8.2.final.0
-virtualenv = 20.0.20
-include-system-site-packages = false
-base-prefix = /usr
-base-exec-prefix = /usr
-base-executable = /usr/bin/python3


### PR DESCRIPTION
Added a keyword for returning the dictionary with the alignment order so that it runs comparably to the Clustal Omega webserver or binary. Only works if there are more than two sequences... ClustalO doesn't calculate the tree_order otherwise. But I got it to not crash at least. 

Also only works on Python versions >3.6, as that was when dictionaries became ordered (otherwise, the order will just be totally random).  

I created an issue for records purposes here: #7